### PR TITLE
Initial support for cancel replce api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-binance-api",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Binance API for node https://github.com/jaggedsoft/node-binance-api",
   "main": "node-binance-api.js",
   "typings": "node-binance-api.d.ts",


### PR DESCRIPTION
partially support the cancelReplace api: 
https://binance-docs.github.io/apidocs/spot/en/#cancel-an-existing-order-and-send-a-new-order-trade

with this support we can replace existing sell limit order with a new one:
create a sell Limit order for `pair`: 
`await binance.sell(pair, qty, price)`
get the order ID and then update with a new sell limit order with a new price
`await binance.sell(pair, qty, newPrice, { type: 'REPLACE', replaceType: 'LIMIT', cancelOrderId: orderIdToReplace})`
